### PR TITLE
Set default DB and user fo the mitimes/db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ db:
   image: mitimes/db
   ports:
     - "5432:5432"
+  environment:
+    - POSTGRES_DB=mitimes_development
+    - POSTGRES_USER=mitimes
+  volumes:
+    - ../docker-postgresql:/data
   expose:
     - "5432"
 redis:


### PR DESCRIPTION
By setting some vars used by the docker init script for postgres, we get the default db and user created. This means you dont' need the manual 'create db' step, or the other odd setups.

https://hub.docker.com/_/postgres/
